### PR TITLE
validate_pgturl: Respecting REQUESTS_CA_BUNDLE environment variable.

### DIFF
--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 import time
 import logging
+import os
 import re
 import requests
 
@@ -278,7 +279,8 @@ class ProxyGrantingTicketManager(TicketManager):
         # Connect to proxy callback URL, checking the SSL certificate
         pgturl = add_query_params(pgturl, {'pgtId': pgtid, 'pgtIou': pgtiou})
         try:
-            r = requests.get(pgturl, verify=True)
+            verify = os.environ.get('REQUESTS_CA_BUNDLE', True)
+            r = requests.get(pgturl, verify=verify)
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.SSLError) as e:
             raise InternalError("%s" % e)


### PR DESCRIPTION
This allows, for example, a local development environment with a self-signed
cert installed as its root CA, and the following:

```
%sudo update-ca-certificates
%export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-certificates.crt'
```

The certificate can then be accepted as valid.

While mama_cas-specific settings are expected to live in settings.py, this env
var is the standard way to specify this value for requests.
