### PR TITLE
replaced django's User model into get_user_model to increase reusability

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Contributors
 
    * Bryan Kaplan
    * Ming Chen
+   * Adilet Maratov
 
 
 If you have contributed to MamaCAS in any substantial way, such as adding

--- a/mama_cas/tests/factories.py
+++ b/mama_cas/tests/factories.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model as User
 from django.utils.timezone import now
 
 import factory


### PR DESCRIPTION
Replaced django's User model into get_user_model in factories. Because there is no auth_user table in db when I use custom User model.