### PR TITLE
Allow for custom login/warn templates

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -187,4 +187,18 @@ customize behavior and improve security.
 
       This setting has been deprecated in favor of MAMA_CAS_SERVICES.
 
+.. attribute:: MAMA_CAS_LOGIN_TEMPLATE
+
+   :default: ``mama_cas/login.html``
+
+   A path to the login template to use. Make sure Django can find this template
+   using normal Django template discovery rules.
+
+.. attribute:: MAMA_CAS_WARN_TEMPLATE
+
+   :default: ``mama_cas/warn.html``
+
+   A path to the warning template to use. Make sure Django can find this
+   template using normal Django template discovery rules.
+
 .. _gevent: http://www.gevent.org/

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -189,14 +189,14 @@ customize behavior and improve security.
 
 .. attribute:: MAMA_CAS_LOGIN_TEMPLATE
 
-   :default: ``mama_cas/login.html``
+   :default: ``'mama_cas/login.html'``
 
    A path to the login template to use. Make sure Django can find this template
    using normal Django template discovery rules.
 
 .. attribute:: MAMA_CAS_WARN_TEMPLATE
 
-   :default: ``mama_cas/warn.html``
+   :default: ``'mama_cas/warn.html'``
 
    A path to the warning template to use. Make sure Django can find this
    template using normal Django template discovery rules.

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -35,6 +35,13 @@ from mama_cas.utils import to_bool
 
 logger = logging.getLogger(__name__)
 
+login_view_template_name = getattr(settings,
+                                   'MAMA_CAS_LOGIN_TEMPLATE',
+                                   'mama_cas/login.html')
+
+warn_view_template_name = getattr(settings,
+                                  'MAMA_CAS_WARN_TEMPLATE',
+                                  'mama_cas/warn.html')
 
 class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
     """
@@ -43,7 +50,7 @@ class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
     This view operates as a credential requestor when a GET request
     is received, and a credential acceptor for POST requests.
     """
-    template_name = 'mama_cas/login.html'
+    template_name = login_view_template_name
     form_class = LoginForm
 
     def get(self, request, *args, **kwargs):
@@ -137,7 +144,7 @@ class WarnView(NeverCacheMixin, LoginRequiredMixin, TemplateView):
     that service authentication is taking place. The user can choose
     to continue or cancel the authentication attempt.
     """
-    template_name = 'mama_cas/warn.html'
+    template_name = warn_view_template_name
 
     def get(self, request, *args, **kwargs):
         service = request.GET.get('service')

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -35,6 +35,7 @@ from mama_cas.utils import to_bool
 
 logger = logging.getLogger(__name__)
 
+
 login_view_template_name = getattr(settings,
                                    'MAMA_CAS_LOGIN_TEMPLATE',
                                    'mama_cas/login.html')
@@ -42,6 +43,7 @@ login_view_template_name = getattr(settings,
 warn_view_template_name = getattr(settings,
                                   'MAMA_CAS_WARN_TEMPLATE',
                                   'mama_cas/warn.html')
+
 
 class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
     """


### PR DESCRIPTION
Re this issue: https://github.com/jbittel/django-mama-cas/issues/38

Is this satisfactory? Currently passes the tox tests