### PR TITLE
Multiple attribute values in SAML responses

### DIFF
--- a/mama_cas/response.py
+++ b/mama_cas/response.py
@@ -230,8 +230,13 @@ class SamlValidationResponse(CasResponseBase):
             attribute = etree.SubElement(attribute_statement, 'Attribute')
             attribute.set('AttributeName', name)
             attribute.set('AttributeNamespace', self.namespace)
-            attribute_value = etree.SubElement(attribute, 'AttributeValue')
-            attribute_value.text = value
+            if isinstance(value, list):
+                for v in value:
+                    attribute_value = etree.SubElement(attribute, 'AttributeValue')
+                    attribute_value.text = v
+            else:
+                attribute_value = etree.SubElement(attribute, 'AttributeValue')
+                attribute_value.text = value
         return attribute_statement
 
     def get_authentication_statement(self, subject, ticket):

--- a/mama_cas/tests/test_response.py
+++ b/mama_cas/tests/test_response.py
@@ -222,3 +222,33 @@ class SamlValidationResponseTests(TestCase):
             # dict is empty to see if all attributes were matched.
             del attrs[attr_name]
         self.assertEqual(len(attrs), 0)
+
+    def test_saml_validation_response_attributes_multiple_values(self):
+        """
+        When given a custom user attribute with a list, a
+        ``SamlValidationResponse`` authentication success should include all
+        the list items as values in the resposne.
+        """
+        attrs = {'givenName': 'Ellen', 'sn': 'Cohen', 'groups': ['group1', 'group2', 'group3']}
+        resp = SamlValidationResponse(context={'ticket': self.st, 'error': None,
+                                               'attributes': attrs},
+                                      content_type='text/xml')
+        attribute_statement = parse(resp.content).find('./Body/Response/Assertion/AttributeStatement')
+        self.assertIsNotNone(attribute_statement)
+        for attr in attribute_statement.findall('Attribute'):
+            attr_name = attr.get('AttributeName')
+            attr_values = attr.findall('AttributeValue')
+            if(len(attr_values) > 1):
+                import sys
+                self.assertEqual(len(attr_values), len(attrs[attr_name]))
+                for attr_value in attr_values:
+                    self.assertTrue(attr_value.text in attrs[attr_name])
+            else:
+                attr_value = attr_values[0]
+                self.assertTrue(attr_name in attrs)
+                self.assertEqual(attr_value.text, attrs[attr_name])
+            # Ordering is not guaranteed, so remove attributes from
+            # the dict as they are validated. When done, check if the
+            # dict is empty to see if all attributes were matched.
+            del attrs[attr_name]
+        self.assertEqual(len(attrs), 0)

--- a/mama_cas/tests/test_response.py
+++ b/mama_cas/tests/test_response.py
@@ -239,7 +239,6 @@ class SamlValidationResponseTests(TestCase):
             attr_name = attr.get('AttributeName')
             attr_values = attr.findall('AttributeValue')
             if(len(attr_values) > 1):
-                import sys
                 self.assertEqual(len(attr_values), len(attrs[attr_name]))
                 for attr_value in attr_values:
                     self.assertTrue(attr_value.text in attrs[attr_name])


### PR DESCRIPTION
I'm not sure if it's defined in the protocol, but the reference CAS implementation (at least v4.0.0) allows multiple <AttributeValue> tags per <Attribute> in SAML responses. This is useful, for example, for a "groups" attribute, with a user belonging to an arbitrary number of groups.

As best as I could tell, you can't presently do this with MamaCAS. If you return a list from an attribute callback, you get an etree serialization error. This PR changes it so that if you return a list from an attribute callback, each element of the list is added as a separate value.

I'm not crazy about giving lists special treatment, but I couldn't come up with a more generic way to determine what the callback intends us to do with the value. You obviously can't just look for iterables, since that includes strings. I suppose you could catch the serialization exception and try iterating over the value instead, but that doesn't feel quite right either. I'm open to suggestions!

Barring suggestions, I don't think making lists a special case is **too** bad, though, because:

1. Lists currently break the response anyway.
2. It seems a natural-enough convention--at least, it's how I assumed it would work when I first experimented.