### PR TITLE
Add support for optional request argument added in Django 1.11

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Contributors
    * Bryan Kaplan
    * Ming Chen
    * Adilet Maratov
+   * Peter Baehr
 
 
 If you have contributed to MamaCAS in any substantial way, such as adding

--- a/mama_cas/forms.py
+++ b/mama_cas/forms.py
@@ -19,6 +19,7 @@ class LoginForm(forms.Form):
                                                _("Please enter your password")})
 
     def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop('request', None)
         super(LoginForm, self).__init__(*args, **kwargs)
         if getattr(settings, 'MAMA_CAS_ALLOW_AUTH_WARN', False):
             self.fields['warn'] = forms.BooleanField(
@@ -38,7 +39,7 @@ class LoginForm(forms.Form):
 
         if username and password:
             try:
-                self.user = authenticate(username=username, password=password)
+                self.user = authenticate(self.request, username=username, password=password)
             except Exception:
                 logger.exception("Error authenticating %s" % username)
                 error_msg = _('Internal error while authenticating user')

--- a/mama_cas/forms.py
+++ b/mama_cas/forms.py
@@ -39,7 +39,7 @@ class LoginForm(forms.Form):
 
         if username and password:
             try:
-                self.user = authenticate(self.request, username=username, password=password)
+                self.user = authenticate(request=self.request, username=username, password=password)
             except Exception:
                 logger.exception("Error authenticating %s" % username)
                 error_msg = _('Internal error while authenticating user')

--- a/mama_cas/tests/backends.py
+++ b/mama_cas/tests/backends.py
@@ -4,13 +4,13 @@ from django.contrib.auth.backends import ModelBackend
 
 class ExceptionBackend(ModelBackend):
     """Raise an exception on authentication for testing purposes."""
-    def authenticate(self, username=None, password=None):
+    def authenticate(self, request, username=None, password=None):
         raise Exception
 
 
 class CaseInsensitiveBackend(ModelBackend):
     """A case-insenstitive authentication backend."""
-    def authenticate(self, username=None, password=None):
+    def authenticate(self, request, username=None, password=None):
         user_model = get_user_model()
         try:
             user = user_model.objects.get(username__iexact=username)

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -56,6 +56,14 @@ class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
     form_class = LoginForm
 
     def get_form_kwargs(self):
+        """
+        Django >= 1.11 supports a request sent to the authenticator
+        so we grab that here and pass it along to the form so it can be
+        handed off to the authenticators.
+        """
+        """
+        :return: 
+        """
         kwargs = super(LoginView, self).get_form_kwargs()
         kwargs['request'] = self.request
         return kwargs

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -61,9 +61,6 @@ class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
         so we grab that here and pass it along to the form so it can be
         handed off to the authenticators.
         """
-        """
-        :return: 
-        """
         kwargs = super(LoginView, self).get_form_kwargs()
         kwargs['request'] = self.request
         return kwargs

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -55,6 +55,11 @@ class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
     template_name = login_view_template_name
     form_class = LoginForm
 
+    def get_form_kwargs(self):
+        kwargs = super(LoginView, self).get_form_kwargs()
+        kwargs['request'] = self.request
+        return kwargs
+
     def get(self, request, *args, **kwargs):
         """
         (2.1) As a credential requestor, /login accepts three optional


### PR DESCRIPTION
Django 1.11 adds a new optional "request" parameter to django.contrib.auth.authenticate which is passed along to authenticators. (https://docs.djangoproject.com/en/1.11/topics/auth/default/#django.contrib.auth.authenticate)

This pull request adds sends the request along to the form so that it can be passed to authenticate in order to maintain compatibility with custom authenticators for Django 1.11 which make use of the request parameter.