### PR TITLE
Allow custom service backends

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -76,6 +76,12 @@ customize behavior and improve security.
    this setting is ``False`` or the parameter is not provided, the client
    is redirected to the login page.
 
+.. attribute:: MAMA_CAS_SERVICE_BACKENDS
+
+   :default: ``['mama_cas.services.backends.SettingsBackend']``
+
+   A list of paths to service backends.
+
 .. attribute:: MAMA_CAS_SERVICES
 
    :default: ``[]``

--- a/mama_cas/services/__init__.py
+++ b/mama_cas/services/__init__.py
@@ -8,7 +8,11 @@ from django.utils.module_loading import import_string
 def _get_backends():
     """Retrieve the list of configured service backends."""
     backends = []
-    for backend_path in ['mama_cas.services.backends.SettingsBackend']:
+    backend_paths = getattr(
+        settings, 'MAMA_CAS_SERVICE_BACKENDS',
+        ['mama_cas.services.backends.SettingsBackend']
+    )
+    for backend_path in backend_paths:
         backend = import_string(backend_path)()
         backends.append(backend)
     return backends

--- a/mama_cas/tests/backends.py
+++ b/mama_cas/tests/backends.py
@@ -1,6 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 
+from mama_cas.services.backends import SettingsBackend
+
 
 class ExceptionBackend(ModelBackend):
     """Raise an exception on authentication for testing purposes."""
@@ -18,3 +20,15 @@ class CaseInsensitiveBackend(ModelBackend):
                 return user
         except user_model.DoesNotExist:
             return None
+
+
+class CustomTestServiceBackend(SettingsBackend):
+    """Service backend that always allows any service containing 'test.com'"""
+    def service_allowed(self, service):
+        if service and "test.com" in service:
+            return True
+        return super(CustomTestServiceBackend, self).service_allowed(service)
+
+
+class CustomTestInvalidServiceBackend(object):
+    pass

--- a/mama_cas/tests/test_services.py
+++ b/mama_cas/tests/test_services.py
@@ -116,3 +116,44 @@ class ServicesTests(TestCase):
         """
         with self.assertRaises(ImproperlyConfigured):
             service_allowed('http://www.example.com')
+
+    @override_settings(
+        MAMA_CAS_SERVICE_BACKENDS=[
+            'mama_cas.tests.backends.CustomTestServiceBackend'
+        ]
+    )
+    def test_custom_backend(self):
+        """
+        Test that a custom service backend can be used
+        """
+        # CustomTestServiceBackend allows any service with 'test.com' in
+        # addition to defined services
+        self.assertFalse(service_allowed('http://www.foo.com'))
+        self.assertTrue(service_allowed('http://www.example.com'))
+        self.assertTrue(service_allowed('http://www.test.com'))
+
+    @override_settings(
+        MAMA_CAS_SERVICE_BACKENDS=[
+            'mama_cas.tests.backends.CustomTestInvalidServiceBackend'
+        ]
+    )
+    def test_invalid_custom_backend(self):
+        """
+        Test that a custom service backend without properly defined
+        attributes raises ``NotImplementedError``
+        """
+
+        with self.assertRaises(NotImplementedError):
+            service_allowed('http://www.example.com')
+
+        with self.assertRaises(NotImplementedError):
+            get_callbacks('http://www.example.com')
+
+        with self.assertRaises(NotImplementedError):
+            get_logout_url('http://www.example.com')
+
+        with self.assertRaises(NotImplementedError):
+            logout_allowed('http://www.example.com')
+
+        with self.assertRaises(NotImplementedError):
+            proxy_allowed('http://www.example.com')


### PR DESCRIPTION
`services/__init.py` contains all the functionality to use multiple backends, but doesn't actually allow a way for users to define and use them.  This commit adds a setting
'MAMA_CAS_SERVICE_BACKENDS' so that this functionality can be accessed.