### PR TITLE
django 2.0 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,6 @@ matrix:
       python: 3.6
     - env: TOX_ENV=py35-djangomaster
       python: 3.5
-    - env: TOX_ENV=py36-django20
-      python: 3.6
-    - env: TOX_ENV=py35-django20
-      python: 3.5
-    - env: TOX_ENV=py34-django20
-      python: 3.4
 install: pip install tox
 
 script: tox -e $TOX_ENV

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Contributors
    * Ming Chen
    * Adilet Maratov
    * Peter Baehr
+   * Manel Clos
 
 
 If you have contributed to MamaCAS in any substantial way, such as adding

--- a/mama_cas/migrations/0001_initial.py
+++ b/mama_cas/migrations/0001_initial.py
@@ -36,8 +36,8 @@ class Migration(migrations.Migration):
                 ('expires', models.DateTimeField(verbose_name='expires')),
                 ('consumed', models.DateTimeField(null=True, verbose_name='consumed')),
                 ('service', models.CharField(max_length=255, verbose_name='service')),
-                ('granted_by_pgt', models.ForeignKey(verbose_name='granted by proxy-granting ticket', to='mama_cas.ProxyGrantingTicket')),
-                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL)),
+                ('granted_by_pgt', models.ForeignKey(verbose_name='granted by proxy-granting ticket', to='mama_cas.ProxyGrantingTicket', on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'proxy ticket',
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
                 ('consumed', models.DateTimeField(null=True, verbose_name='consumed')),
                 ('service', models.CharField(max_length=255, verbose_name='service')),
                 ('primary', models.BooleanField(default=False, verbose_name='primary')),
-                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'service ticket',
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='proxygrantingticket',
             name='user',
-            field=models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -160,7 +160,8 @@ class Ticket(models.Model):
     TICKET_RE = re.compile("^[A-Z]{2,3}-[0-9]{10,}-[a-zA-Z0-9]{%d}$" % TICKET_RAND_LEN)
 
     ticket = models.CharField(_('ticket'), max_length=255, unique=True)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('user'),
+                             on_delete=models.CASCADE)
     expires = models.DateTimeField(_('expires'))
     consumed = models.DateTimeField(_('consumed'), null=True)
 
@@ -267,7 +268,8 @@ class ProxyTicket(Ticket):
 
     service = models.CharField(_('service'), max_length=255)
     granted_by_pgt = models.ForeignKey('ProxyGrantingTicket',
-                                       verbose_name=_('granted by proxy-granting ticket'))
+                                       verbose_name=_('granted by proxy-granting ticket'),
+                                       on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = _('proxy ticket')

--- a/mama_cas/tests/settings.py
+++ b/mama_cas/tests/settings.py
@@ -19,13 +19,15 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
+
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 TEMPLATES = [
     {

--- a/mama_cas/tests/test_views.py
+++ b/mama_cas/tests/test_views.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 
 from mock import patch
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django<2.0
+    from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/mama_cas/tests/utils.py
+++ b/mama_cas/tests/utils.py
@@ -1,6 +1,9 @@
 import re
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django<2.0
+    from django.core.urlresolvers import reverse
 
 from mama_cas.compat import etree
 from mama_cas.compat import urlencode

--- a/mama_cas/utils.py
+++ b/mama_cas/utils.py
@@ -2,7 +2,11 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core import urlresolvers
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:  # Django<2.0
+    from django.core.urlresolvers import reverse, NoReverseMatch
+
 from django.http import HttpResponseRedirect
 from django.utils.encoding import force_bytes
 
@@ -73,10 +77,10 @@ def redirect(to, *args, **kwargs):
     params = kwargs.pop('params', {})
 
     try:
-        to = urlresolvers.reverse(to, args=args, kwargs=kwargs)
-    except urlresolvers.NoReverseMatch:
+        to = reverse(to, args=args, kwargs=kwargs)
+    except NoReverseMatch:
         if '/' not in to and '.' not in to:
-            to = urlresolvers.reverse('cas_login')
+            to = reverse('cas_login')
         elif not service_allowed(to):
             raise PermissionDenied()
 


### PR DESCRIPTION
Django 2.0 compatibility.
Check travis results https://travis-ci.org/manelclos/django-mama-cas/builds/317195100

or rerun travis build after merging https://github.com/jbittel/django-mama-cas/pull/55

After merging this PR would be good to take django 2.0 out of travis allowed_failures.
