### PR TITLE
fix documentation links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,5 +35,5 @@ Contents
    changelog
 
 .. _Central Authentication Service (CAS):
-.. _CAS: http://jasig.github.io/cas/
+.. _CAS: http://apereo.github.io/cas/
 .. _github.com/jbittel/django-mama-cas: https://github.com/jbittel/django-mama-cas

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -42,5 +42,5 @@ contract between the client, service and CAS server.
    uses Django sessions to determine if a single sign-on session has been
    established.
 
-.. _CAS Protocol: http://apereo.github.io/cas/4.0.x/protocol/CAS-Protocol.html
+.. _CAS Protocol: https://apereo.github.io/cas/5.2.x/protocol/CAS-Protocol.html
 .. _CAS User Manual: http://apereo.github.io/cas/

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -47,6 +47,3 @@ contract between the client, service and CAS server.
 
 .. _CAS Protocol: http://apereo.github.io/cas/4.0.x/protocol/CAS-Protocol.html
 .. _CAS User Manual: http://apereo.github.io/cas/
-.. _CAS 1 Architecture: https://www.apereo.org/projects/cas/cas-1-architecture
-.. _CAS 2 Architecture: https://www.apereo.org/content/cas-2-architecture
-.. _Proxy Authentication: https://www.apereo.org/content/why-do-we-need-proxy-authentication

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -4,7 +4,7 @@ CAS Protocol
 ============
 
 The official CAS protocol specification can be found at
-http://jasig.github.io/cas/. Where appropriate, docstrings and other
+http://apereo.github.io/cas/. Where appropriate, docstrings and other
 documentation include numbers in parenthesis (e.g. ``(2.3)``) corresponding
 to the section number within the CAS protocol documentation where that
 functionality is described. Additionally, views are labeled with a CAS version
@@ -45,8 +45,8 @@ contract between the client, service and CAS server.
    uses Django sessions to determine if a single sign-on session has been
    established.
 
-.. _CAS Protocol: http://jasig.github.io/cas/4.0.x/protocol/CAS-Protocol.html
-.. _CAS User Manual: http://jasig.github.io/cas/
+.. _CAS Protocol: http://apereo.github.io/cas/4.0.x/protocol/CAS-Protocol.html
+.. _CAS User Manual: http://apereo.github.io/cas/
 .. _CAS 1 Architecture: https://www.apereo.org/projects/cas/cas-1-architecture
 .. _CAS 2 Architecture: https://www.apereo.org/content/cas-2-architecture
 .. _Proxy Authentication: https://www.apereo.org/content/why-do-we-need-proxy-authentication

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -21,9 +21,6 @@ response endpoint.
 
    * `CAS Protocol`_
    * `CAS User Manual`_
-   * `CAS 1 Architecture`_
-   * `CAS 2 Architecture`_
-   * `Proxy Authentication`_
 
 Protocol Deviations
 -------------------


### PR DESCRIPTION
Fixes https://github.com/jbittel/django-mama-cas/issues/57

The links to the CAS 1 and 2 architecture are also broken on https://wiki.jasig.org/display/CAS/Home, so maybe we should delete them?