### PR TITLE
remove python 3.3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ matrix:
       python: 3.5
     - env: TOX_ENV=py34-django18
       python: 3.4
-    - env: TOX_ENV=py33-django18
-      python: 3.3
     - env: TOX_ENV=py27-django18
       python: 2.7
     - env: TOX_ENV=flake8


### PR DESCRIPTION
Tests are failing because pkg_resources (setuptools) no longer supports python 3.3