### PR TITLE
SECURITY: don't allow any service url if custom services backend is used

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Contributors
    * Adilet Maratov
    * Peter Baehr
    * Manel Clos
+   * Jenny Danzmayr
 
 
 If you have contributed to MamaCAS in any substantial way, such as adding

--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -131,8 +131,8 @@ class TicketManager(models.Manager):
         A custom management command is provided that executes this method
         on all applicable models by running ``manage.py cleanupcas``.
         """
-        for ticket in self.filter(Q(consumed__isnull=False) |
-                                  Q(expires__lte=now())).order_by('-expires'):
+        for ticket in self.filter(Q(consumed__isnull=False)
+                                  | Q(expires__lte=now())).order_by('-expires'):
             try:
                 ticket.delete()
             except models.ProtectedError:

--- a/mama_cas/services/__init__.py
+++ b/mama_cas/services/__init__.py
@@ -117,6 +117,6 @@ def proxy_callback_allowed(service, pgturl):
 
 def service_allowed(service):
     """Check if a given service identifier is authorized."""
-    if hasattr(settings, 'MAMA_CAS_SERVICES'):
+    if hasattr(settings, 'MAMA_CAS_SERVICES') or hasattr(settings, 'MAMA_CAS_SERVICE_BACKENDS'):
         return _is_allowed('service_allowed', service)
     return _is_valid_service_url(service)

--- a/mama_cas/tests/backends.py
+++ b/mama_cas/tests/backends.py
@@ -30,5 +30,13 @@ class CustomTestServiceBackend(SettingsBackend):
         return super(CustomTestServiceBackend, self).service_allowed(service)
 
 
+class CustomTestServiceBackendNoSettings(SettingsBackend):
+    """Service backend that only allows any service containing 'test.com'"""
+    def service_allowed(self, service):
+        if service and "test.com" in service:
+            return True
+        return False
+
+
 class CustomTestInvalidServiceBackend(object):
     pass

--- a/mama_cas/tests/settings.py
+++ b/mama_cas/tests/settings.py
@@ -54,9 +54,9 @@ INSTALLED_APPS = (
 
 MAMA_CAS_SERVICES = [
     {
-        'SERVICE': 'https?://.+\.example\.com',
+        'SERVICE': r'https?://.+\.example\.com',
         'PROXY_ALLOW': True,
-        'PROXY_PATTERN': 'https://.+\.example\.com',
+        'PROXY_PATTERN': r'https://.+\.example\.com',
         'CALLBACKS': [
             'mama_cas.callbacks.user_name_attributes',
         ],

--- a/mama_cas/tests/test_services.py
+++ b/mama_cas/tests/test_services.py
@@ -48,7 +48,7 @@ class ServicesTests(TestCase):
         self.assertFalse(logout_allowed('http://www.example.org'))
 
     @modify_settings(MAMA_CAS_SERVICES={
-        'append': [{'SERVICE': 'http://example\.org/proxy'}]
+        'append': [{'SERVICE': r'http://example\.org/proxy'}]
     })
     def test_proxy_allowed(self):
         """
@@ -71,7 +71,7 @@ class ServicesTests(TestCase):
         self.assertFalse(proxy_callback_allowed('https://www.example.com', 'https://www.example.org'))
         self.assertFalse(proxy_callback_allowed('http://example.org', 'http://example.org'))
 
-    @override_settings(MAMA_CAS_VALID_SERVICES=('http://.*\.example\.com',))
+    @override_settings(MAMA_CAS_VALID_SERVICES=(r'http://.*\.example\.com',))
     def test_service_allowed_tuple(self):
         """
         When valid services are configured, ``service_allowed()``

--- a/mama_cas/tests/test_services.py
+++ b/mama_cas/tests/test_services.py
@@ -134,6 +134,22 @@ class ServicesTests(TestCase):
 
     @override_settings(
         MAMA_CAS_SERVICE_BACKENDS=[
+            'mama_cas.tests.backends.CustomTestServiceBackendNoSettings'
+        ]
+    )
+    def test_custom_backend_security(self):
+        """
+        Test that a custom service backend can be used and it's service_allowed function is respected, also when the
+        `MAMA_CAS_SERVICES` setting isn't present in the django settings.py
+        """
+        del settings.MAMA_CAS_SERVICES
+        # CustomTestServiceBackendNoSettings allows only services containing 'test.com'
+        self.assertFalse(service_allowed('http://www.foo.com'))
+        self.assertFalse(service_allowed('http://www.example.com'))
+        self.assertTrue(service_allowed('http://www.test.com'))
+
+    @override_settings(
+        MAMA_CAS_SERVICE_BACKENDS=[
             'mama_cas.tests.backends.CustomTestInvalidServiceBackend'
         ]
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = build/,docs/,mama_cas/compat.py,mama_cas/migrations/
-ignore = E126,E128
+ignore = E126,E128,W503
 max-line-length = 119
 
 [wheel]


### PR DESCRIPTION
I discovered a bug where when you use a custom services backend and hence not have a `MAMA_CAS_SERVICES` setting the logic falls back to depreciated `MAMA_CAS_VALID_SERVICES` setting which in that case most likely is also not present, which in turn causes django-mama-cas to treat **ANY** service url as valid.

This PR fixes the issue.