### PR TITLE
Makes SSL certification validation configurable

### DIFF
--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -214,6 +214,7 @@ class ServiceTicketManager(TicketManager):
         be sent. Otherwise, synchronous requests will be sent.
         """
         session = Session()
+        session.verify = getattr(settings, 'MAMA_CAS_VERIFY_SSL_CERTIFICATE', True)
         for ticket in self.filter(user=user, consumed__gte=user.last_login):
             ticket.request_sign_out(session=session)
 


### PR DESCRIPTION
If MAMA_CAS_VERIFY_SSL_CERTIFICATE == False then SSL certificates are not verified. This configuration is useful for localdev with self-signed certificates (eg. generated by mkcert).