### PR TITLE
Modify the source of python_2_unicode_compatible

### DIFF
--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.utils.crypto import get_random_string
-from django.utils.encoding import python_2_unicode_compatible
+# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
@@ -149,7 +149,7 @@ class TicketManager(models.Manager):
             ticket.consume()
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class Ticket(models.Model):
     """
     ``Ticket`` is an abstract base class implementing common methods

--- a/mama_cas/models.py
+++ b/mama_cas/models.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.utils.crypto import get_random_string
-# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 import requests
@@ -149,7 +149,7 @@ class TicketManager(models.Manager):
             ticket.consume()
 
 
-# @python_2_unicode_compatible
+@python_2_unicode_compatible
 class Ticket(models.Model):
     """
     ``Ticket`` is an abstract base class implementing common methods


### PR DESCRIPTION
Encoding import python_2_unicode_compatible has expired in django==3.0.1.
Use the more generic from six import python_2_unicode_compatible instead