### PR TITLE
Add MAMA_CAS_INTERNAL_LOGIN_REDIRECT settings option

### DIFF
--- a/mama_cas/tests/test_views.py
+++ b/mama_cas/tests/test_views.py
@@ -21,6 +21,7 @@ from mama_cas.views import ValidateView
 from mama_cas.views import SamlValidateView
 
 
+@override_settings(ROOT_URLCONF='mama_cas.tests.urls')
 class LoginViewTests(TestCase):
     user_info = {'username': 'ellen',
                  'password': 'mamas&papas'}
@@ -51,15 +52,28 @@ class LoginViewTests(TestCase):
         self.assertTrue('Cache-Control' in response)
         self.assertTrue('max-age=0' in response['Cache-Control'])
 
-    def test_login_view_login(self):
+    def test_login_view_no_service_default(self):
         """
         When called with a valid username and password and no service,
-        a ``POST`` request to the view should authenticate and login
-        the user, and redirect to the correct view.
+        and MAMA_CAS_INTERNAL_LOGIN_REDIRECT is not set, a ``POST``
+        request to the view should authenticate and login the user,
+        and redirect to the cas_login view.
         """
         response = self.client.post(reverse('cas_login'), self.user_info)
         self.assertEqual(int(self.client.session['_auth_user_id']), self.user.pk)
         self.assertRedirects(response, reverse('cas_login'))
+    
+    @override_settings(MAMA_CAS_INTERNAL_LOGIN_REDIRECT='custom_internal_login_redirect')
+    def test_login_view_no_service_custom(self):
+        """
+        When called with a valid username and password and no service,
+        and MAMA_CAS_INTERNAL_LOGIN_REDIRECT is set, a ``POST`` request
+        to the view should authenticate and login the user, and redirect
+        to the MAMA_CAS_INTERNAL_LOGIN_REDIRECT view.
+        """
+        response = self.client.post(reverse('cas_login'), self.user_info)
+        self.assertEqual(int(self.client.session['_auth_user_id']), self.user.pk)
+        self.assertRedirects(response, reverse('custom_internal_login_redirect'))
 
     def test_login_view_login_service(self):
         """

--- a/mama_cas/tests/urls.py
+++ b/mama_cas/tests/urls.py
@@ -1,0 +1,12 @@
+from django.urls import re_path, include
+
+from mama_cas.tests.views import CustomInternalLoginRedirectView
+
+urlpatterns = [
+    re_path("", include("mama_cas.urls")),
+    re_path(
+        "custom_internal_login_redirect/",
+        CustomInternalLoginRedirectView.as_view(),
+        name="custom_internal_login_redirect",
+    ),
+]

--- a/mama_cas/tests/views.py
+++ b/mama_cas/tests/views.py
@@ -1,0 +1,7 @@
+from django.views import View
+from django.http import HttpResponse
+
+
+class CustomInternalLoginRedirectView(View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("CustomInternalLoginRedirectView response")

--- a/mama_cas/views.py
+++ b/mama_cas/views.py
@@ -146,7 +146,8 @@ class LoginView(CsrfProtectMixin, NeverCacheMixin, FormView):
         if service:
             st = ServiceTicket.objects.create_ticket(service=service, user=self.request.user, primary=True)
             return redirect(service, params={'ticket': st.ticket})
-        return redirect('cas_login')
+        no_service_redirect_url = getattr(settings, 'MAMA_CAS_INTERNAL_LOGIN_REDIRECT', 'cas_login')
+        return redirect(no_service_redirect_url)
 
 
 class WarnView(NeverCacheMixin, LoginRequiredMixin, TemplateView):


### PR DESCRIPTION
Adds an optional MAMA_CAS_INTERNAL_LOGIN_REDIRECT setting so users can be redirected to another page when logging in directly from the cas app as opposed to logging in through a service